### PR TITLE
remove this line from the text and buttons elements:

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -73,15 +73,13 @@
         color: $color-black;
         font-size: $text-size-medium;
         word-wrap: break-word;
-        word-break: break-word;        
-        -ms-word-break: break-all;
+        word-break: break-word;
     }
 
     .lp-json-pollock-element-button {
         width: 100%;
         word-break: break-word;
         word-wrap: break-word;
-        -ms-word-break: break-all;
         button {
             border: none;            
             background: none;


### PR DESCRIPTION
-ms-word-break: break-all;
it breaks words in the middle at line end in explorer