### PR TITLE
[CAO-18250] - Fixed button text overflow in carousel

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -255,6 +255,7 @@
             text-align: center;
             color: $color-blue;
             padding: 10px;
+            white-space: pre-wrap;
             &:active {
                 background: $gray7;
             }


### PR DESCRIPTION
Just added `white-space: pre-wrap;` to button CSS to fix  button text-overflow in a carousel