### PR TITLE
[CAO-17962] Fixed issue with carousel arrows for rtl languages

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -178,6 +178,7 @@
     .lp-json-pollock-layout-carousel-wrapper {
         overflow: hidden;
         position: relative;
+        direction: ltr;
         &:hover{
             .lp-json-pollock-layout-carousel-arrow{
                 opacity: 1;


### PR DESCRIPTION
Unified window styles overriding styles of json-pollock library, just added 
```css
    .lp-json-pollock-layout-carousel-wrapper {
        direction: ltr;
  }
```
to prevent overriding by next style
```css
.lp-window-root.lp_main_rtl * {
    direction: rtl;
    text-align: right;
}
```