### PR TITLE
Fixed carousel issue when carousel not moving to last element

### DIFF
--- a/js/ElementRendererProvider.js
+++ b/js/ElementRendererProvider.js
@@ -351,7 +351,7 @@ export default class ElementRendererProvider {
 
         // Right align the last card in the carousel
         if (carouselItemIndex === cards.length - 1) {
-          nextLeft = `-${cards[carouselItemIndex].offsetLeft - (divCarouselWrapper.offsetWidth - cards[carouselItemIndex].offsetWidth)}px`;
+          nextLeft = `${-1 * (cards[carouselItemIndex].offsetLeft - (divCarouselWrapper.offsetWidth - cards[carouselItemIndex].offsetWidth))}px`;
         }
 
         if (this && this.events) {
@@ -445,7 +445,7 @@ export default class ElementRendererProvider {
               arrowRight.style.visibility = 'hidden';
               carouselItemIndex = cards.length - 1;
               cards = [].slice.call(cards, 0).reverse();
-              nextLeft = `-${cards[carouselItemIndex].offsetLeft - (divCarouselWrapper.offsetWidth - cards[carouselItemIndex].offsetWidth)}px`;
+              nextLeft = `${-1 * (cards[carouselItemIndex].offsetLeft - (divCarouselWrapper.offsetWidth - cards[carouselItemIndex].offsetWidth))}px`;
               (carousel: any).style.left = nextLeft;
             }
           }, 0);


### PR DESCRIPTION
Fixed issue when we try to apply not valid value for `style.left` property. For example, in some cases, we tried to set a value like  `--5px` that is not valid. Just changed `-` before expression to `-1*` to avoid `--` before value