### PR TITLE
CAO-20317 Move title attribute from image to image container

### DIFF
--- a/js/ElementRendererProvider.js
+++ b/js/ElementRendererProvider.js
@@ -288,7 +288,7 @@ export default class ElementRendererProvider {
 
       imgEl.src = config.url;
       if (config.tooltip && config.tooltip.length) {
-        imgEl.title = config.tooltip;
+        divEl.title = config.tooltip;
         imgEl.setAttribute('alt', config.tooltip);
       } else {
         imgEl.setAttribute('role', 'presentation');

--- a/test/test_bundle.js
+++ b/test/test_bundle.js
@@ -329,7 +329,7 @@ describe('json-pollock tests', function () {
       chai.expect(layout.childNodes[0].childNodes[0].textContent).to.equal('this is a caption');
       chai.expect(layout.childNodes[0].childNodes[1].localName).to.equal('img');
       chai.expect(layout.childNodes[0].childNodes[1].src).to.contain('assets/iphone-8-concept.jpg');
-      chai.expect(layout.childNodes[0].childNodes[1].title).to.equal('image tooltip');
+      chai.expect(layout.childNodes[0].title).to.equal('image tooltip');
       var origOnload = image.onload;
       image.onload = function() {
         origOnload.apply(this);
@@ -2388,7 +2388,7 @@ describe('json-pollock tests', function () {
         chai.expect(layout.childNodes[0].className).to.contain('lp-json-pollock-element-image');  //it can also includes loading
         chai.expect(layout.childNodes[0].childNodes[1].localName).to.equal('img');
         chai.expect(layout.childNodes[0].childNodes[1].src).to.contain('assets/iphone-8-concept.jpg');
-        chai.expect(layout.childNodes[0].childNodes[1].title).to.equal('image tooltip');
+        chai.expect(layout.childNodes[0].title).to.equal('image tooltip');
       });
 
     });


### PR DESCRIPTION
This is a continuation of CAO-20317, previous PR #52 

This moves the title attribute from the image element to the container div element, allowing for mouse hover to still show tooltip while stopping certain screen readers from reading duplicate image title and alt text.

@meirotstein I recommend considering adding "alt" text as a supported property on image object -- they both have different meanings in accessibility and customers may want that support in the future. For instance, an image with text may have a simple title "5gb plan", while the alt will be required to list all text within the image. "5gb plan $50/per month terms apply"