### PR TITLE
CAO-21053: Next/Previous button contrast

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -5,6 +5,7 @@ $text-size-medium-large: 15px;
 $text-size-large: 17px;
 $color-black: #000000;
 $color-blue: #0363ad;
+$color-dark-blue: #025494;
 $gray7 : #f0f0f0;
 $disabled-text-grey: #aaaaaa;
 $color-white: #ffffff;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -185,7 +185,7 @@
             }
         };
         >.lp-json-pollock-layout-carousel-arrow {
-            opacity: 0.5;
+            opacity: 0.8;
             z-index: 1;
             right: 0px;
             cursor: pointer;
@@ -198,7 +198,7 @@
             background-color: $color-white;
             text-align: center;
             padding: 0;
-            fill: $color-blue;
+            fill: $color-dark-blue;
             &.left {
                 visibility: hidden;
                 left: 0px;


### PR DESCRIPTION
Increase opacity and decrease color brightness so that in inactive/transparent state, there is 3:1 contrast with the text behind the buttons.