### PR TITLE
Add circular navigation and labels

### DIFF
--- a/examples/carousel_maps.html
+++ b/examples/carousel_maps.html
@@ -1,0 +1,264 @@
+<!doctype html>
+
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+
+  <title>SC Test</title>
+    <link rel="stylesheet" href="/dist/json-pollock.min.css">
+  <script src="/dist/json-pollock.js"></script>
+  <script>
+    window.onload = function () {
+
+      var carousel = {
+          "type": "carousel",
+          "padding": 10,
+          "elements": [
+              {
+                  "type": "vertical",
+                  "elements": [
+                      {
+                          "type": "map",
+                          "lo": -118.243685,
+                          "la": 34.052234,
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "12345678"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": -118.243685,
+                                      "la": 34.052234
+                                  }
+                              ]
+                          }
+                      },
+                      {
+                          "type": "button",
+                          "title": "LA, California, USA",
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "ANOTHER_ONE_1"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": -118.243685,
+                                      "la": 34.052234
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+              },
+              {
+                  "type": "vertical",
+                  "elements": [
+                      {
+                          "type": "map",
+                          "lo": 13.404953999999975,
+                          "la": 52.52000659999999,
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "12345678"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 13.404953999999975,
+                                      "la": 52.52000659999999
+                                  }
+                              ]
+                          }
+                      },
+                      {
+                          "type": "button",
+                          "title": "Berlin, Germany",
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "ANOTHER_ONE_1"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 13.404954,
+                                      "la": 52.520007
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+              },
+              {
+                  "type": "vertical",
+                  "elements": [
+                      {
+                          "type": "map",
+                          "lo": 34.84764575958252,
+                          "la": 32.0852999,
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "12345678"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 34.84764575958252,
+                                      "la": 32.0852999
+                                  }
+                              ]
+                          }
+                      },
+                      {
+                          "type": "button",
+                          "title": "Tel Aviv-Yafo, Israel",
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "ANOTHER_ONE_1"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 34.84764575958252,
+                                      "la": 32.0852999
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+              },
+              {
+                  "type": "vertical",
+                  "elements": [
+                      {
+                          "type": "map",
+                          "lo": 34.98957100000007,
+                          "la": 32.7940463,
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "12345678"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 34.98957100000007,
+                                      "la": 32.7940463
+                                  }
+                              ]
+                          }
+                      },
+                      {
+                          "type": "button",
+                          "title": "Lima, Peru",
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "ANOTHER_ONE_1"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 34.98957100000007,
+                                      "la": 32.7940463
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+              },
+              {
+                  "type": "vertical",
+                  "elements": [
+                      {
+                          "type": "map",
+                          "lo": 34.98957100000007,
+                          "la": 32.7940463,
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "12345678"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 34.98957100000007,
+                                      "la": 32.7940463
+                                  }
+                              ]
+                          }
+                      },
+                      {
+                          "type": "button",
+                          "title": "Haifa, Israel",
+                          "click": {
+                              "metadata": [
+                                  {
+                                      "type": "ExternalId",
+                                      "id": "ANOTHER_ONE_1"
+                                  }
+                              ],
+                              "actions": [
+                                  {
+                                      "type": "navigate",
+                                      "lo": 34.98957100000007,
+                                      "la": 32.7940463
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+              }
+          ]
+      };
+
+      JsonPollock.registerAction('navigate', (data) => {
+        alert(JSON.stringify(data));
+      });
+
+      JsonPollock.registerAction('link', (data) => {
+        alert(JSON.stringify(data));
+      });
+
+      JsonPollock.registerAction('publishText', (data) => {
+        alert(JSON.stringify(data));
+      });
+
+      const el = JsonPollock.render(JSON.stringify(carousel));
+      document.getElementById('content').appendChild(el);
+    }
+  </script>
+</head>
+
+<body>
+  <div id='content' style="max-width:300px;">
+  </div>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
-
 {
   "name": "json-pollock",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Renders live DOM elements out of JSON according to the Structured Messaging Templates spec",
   "repository": "LivePersonInc/json-pollock",
   "main": "index.js",

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -232,7 +232,6 @@
             padding: 0;
             fill: $color-dark-blue;
             &.left {
-                visibility: hidden;
                 left: 0px;
                 .lp-json-pollock-layout-carousel-arrow-icon {
                     transform: rotate(180deg);


### PR DESCRIPTION
This fix adds a circular navigation to the existing carousel implementation along with some screenreader changes.

Previously, we only used to have one-sided direction on carousel (LTR). Now updating the index with the arrow click adds a circular navigation. Also adjusted the HTML structure of buttons. Now, the Previous and Next button get the first navigation focus and then the focus goes inside the carousel elements.  Additionally, the screenreader feature is also added for each item when the Previous and Next button are pressed. So now once the Previous/Next button are pressed a hidden a11yDiv is added to announce eg: 'Item 1 of 4'.

Also added a new sample example file of carousel with maps.