### PR TITLE
[Feature] [CAO-22347] Send only active multi data

### DIFF
--- a/examples/carousel_select.html
+++ b/examples/carousel_select.html
@@ -248,8 +248,10 @@
          * Rendering logic
          * */
         const elMultiple = JsonPollock.render(JSON.stringify(multiCard));
+        const elMultiple2 = JsonPollock.render(JSON.stringify(multiCard));
 
         document.getElementById("content-multi").appendChild(elMultiple);
+        document.getElementById("content-multi-2").appendChild(elMultiple2);
 
         const elSingle = JsonPollock.render(JSON.stringify(singleCard));
 
@@ -261,6 +263,15 @@
   <body>
     <h1>Multi select example</h1>
     <div id="content-multi" style="max-width: 300px"></div>
+
+    <h1>Second Multi select example</h1>
+    <p>
+      Here's an example where the second multi-select shares the same name as
+      the first. Consequently, the code will no longer search for the first
+      multi-select and instead focus solely on this particular node.
+    </p>
+    <div id="content-multi-2" style="max-width: 300px"></div>
+
     <h1>Single select example</h1>
     <div id="content-single" style="max-width: 300px"></div>
   </body>

--- a/js/ElementRendererProvider.js
+++ b/js/ElementRendererProvider.js
@@ -95,6 +95,19 @@ export default class ElementRendererProvider {
         Utils.appendAttributesFromObject(btnEl, config.accessibility.web);
       }
 
+      function findJsonPollockParent(element: any): HTMLDivElement | typeof undefined {
+        if (!element) {
+          return undefined;
+        }
+
+        const matches = element.matches('[class="lp-json-pollock"]');
+        if (matches) {
+          return element;
+        }
+
+        return findJsonPollockParent(element.parentNode);
+      }
+
       const clickData = config.click;
 
       if (clickData && clickData.actions) {
@@ -104,6 +117,12 @@ export default class ElementRendererProvider {
           const newMetadata = [...(metadata || [])];
 
           if (config.ref) {
+            const jsonPollockElement = findJsonPollockParent(btnEl);
+
+            if (!jsonPollockElement) {
+              throw new Error('Cannot find root element selected!');
+            }
+
             let selector;
 
             switch (config.ref.type) {
@@ -119,7 +138,7 @@ export default class ElementRendererProvider {
                 throw new Error(`Invalid config ref type is used for the button! Type: ${config.ref.type}`);
             }
 
-            const selectedNodes = Array.from(document.querySelectorAll(selector));
+            const selectedNodes = Array.from(jsonPollockElement.querySelectorAll(selector));
 
             if (selectedNodes.length === 0) {
               throw new Error('No items has selected!');


### PR DESCRIPTION
If the same element is sent twice in a flow, a bug is causing the selected cards from the previous carousel to be sent together with the currently chosen cards.

This Pull Request fixes the bug.

The only concern I have: we use the `.matches` selector, which is available only from 2015