### PR TITLE
[Feature] [CAO-22348] Update multi metadata schema

### DIFF
--- a/examples/carousel_select.html
+++ b/examples/carousel_select.html
@@ -238,6 +238,7 @@
 
         JsonPollock.registerAction("publishText", (data) => {
           alert(JSON.stringify(data));
+          console.log("publishText", data);
         });
 
         JsonPollock.registerAction("select", (data) => {

--- a/examples/carousel_select.html
+++ b/examples/carousel_select.html
@@ -27,7 +27,7 @@
               type: "vertical",
               metadata: [
                 {
-                  type: "ExternalCardId",
+                  type: "ExternalId",
                   id: "ANOTHER_ONE_1",
                 },
               ],
@@ -79,7 +79,7 @@
               type: "vertical",
               metadata: [
                 {
-                  type: "ExternalCardId",
+                  type: "ExternalId",
                   id: "ANOTHER_ONE_2",
                 },
               ],
@@ -132,7 +132,7 @@
               type: "vertical",
               metadata: [
                 {
-                  type: "ExternalCardId",
+                  type: "ExternalId",
                   id: "ANOTHER_ONE_3",
                 },
               ],

--- a/js/ElementRendererProvider.js
+++ b/js/ElementRendererProvider.js
@@ -123,7 +123,11 @@ export default class ElementRendererProvider {
               throw new Error('No items has selected!');
             }
 
-            newMetadata.push(...selectedNodes.map(node => JSON.parse(node.getAttribute('data-metadata') || '[]')[0]));
+            const selectedCardsMetadata = selectedNodes
+              .map(node => JSON.parse(node.getAttribute('data-metadata') || '[]'))
+              .reduce((accumulator, currentMeta) => [...accumulator, currentMeta], []);
+
+            newMetadata.push(...selectedCardsMetadata);
           }
 
           return this.wrapAction({ ...clickData, metadata: newMetadata })(event, formEl);

--- a/js/ElementRendererProvider.js
+++ b/js/ElementRendererProvider.js
@@ -125,7 +125,7 @@ export default class ElementRendererProvider {
 
             const selectedCardsMetadata = selectedNodes
               .map(node => JSON.parse(node.getAttribute('data-metadata') || '[]'))
-              .reduce((accumulator, currentMeta) => [...accumulator, currentMeta], []);
+              .reduce((accumulator, currentMeta) => [...accumulator, ...currentMeta], []);
 
             newMetadata.push(...selectedCardsMetadata);
           }

--- a/js/ElementRendererProvider.js
+++ b/js/ElementRendererProvider.js
@@ -98,10 +98,8 @@ export default class ElementRendererProvider {
       const clickData = config.click;
 
       if (clickData && clickData.actions) {
-        const { metadata } = clickData;
-
         btnEl.onclick = (event, formEl) => {
-          const newMetadata = [...(metadata || [])];
+          const newMetadata = [];
 
           if (config.ref) {
             let selector;
@@ -125,7 +123,7 @@ export default class ElementRendererProvider {
               throw new Error('No items has selected!');
             }
 
-            newMetadata.push({ type: 'selectedCards', cards: selectedNodes.map(node => JSON.parse(node.getAttribute('data-metadata') || 'null')) });
+            newMetadata.push(...selectedNodes.map(node => JSON.parse(node.getAttribute('data-metadata') || '[]')[0]));
           }
 
           return this.wrapAction({ ...clickData, metadata: newMetadata })(event, formEl);


### PR DESCRIPTION
Currently, we use another metadata type. This PR updates this data to be simpler without `selectedCards`

<img width="672" alt="image" src="https://github.com/LivePersonInc/json-pollock/assets/80344079/c76ab5f4-d39a-47c3-939f-78e62095a711">
