### PR TITLE
Add visibility from js for lower versions

### DIFF
--- a/js/ElementRendererProvider.js
+++ b/js/ElementRendererProvider.js
@@ -645,6 +645,7 @@ export default class ElementRendererProvider {
 
       arrowLeft.setAttribute('type', 'button');
       arrowLeft.setAttribute('aria-label', 'Previous');
+      arrowLeft.style.visibility = 'visible'; // CAO-22400 forcing visibility through js for older versions
       arrowRight.setAttribute('type', 'button');
       arrowRight.setAttribute('aria-label', 'Next');
       a11yDiv.setAttribute('aria-live', 'polite');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-pollock",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Renders live DOM elements out of JSON according to the Structured Messaging Templates spec",
   "repository": "LivePersonInc/json-pollock",
   "main": "index.js",

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -238,6 +238,7 @@
             padding: 0;
             fill: $color-dark-blue;
             &.left {
+                visibility: hidden;
                 left: 0px;
                 .lp-json-pollock-layout-carousel-arrow-icon {
                     transform: rotate(180deg);


### PR DESCRIPTION
In some modules styles get applied from old version but Json-pollock logic is added from the new version.
So, this reverts the css changes from https://github.com/LivePersonInc/json-pollock/pull/94/files and this css is now added from the JS